### PR TITLE
Fixs bugs

### DIFF
--- a/src/ui/AfficheurJeu.rb
+++ b/src/ui/AfficheurJeu.rb
@@ -106,7 +106,7 @@ class AfficheurJeu < Gtk::Paned
         @hypothese = Gtk::Stack.new()
         @boutonHypothese = Gtk::Button.new(:label => "Hypothèse")
         @boutonHypothese.signal_connect("clicked") { |widget| @grille.commencerHypothese(); @hypothese.visible_child = @boxHypothese; @afficheurGrille.queue_draw() }
-        @hypothese.add_named(@boutonHypothese, "Inactif")
+        @hypothese.add(@boutonHypothese)
 
         @boxHypothese = Gtk::Box.new(Gtk::Orientation.new(0), 0)
         @boutonValiderHypothese = Gtk::Button.new(:label => "Valider")
@@ -118,9 +118,11 @@ class AfficheurJeu < Gtk::Paned
 
         @boxHypothese.add(@boutonAnnulerHypothese)
         @boxHypothese.add(@boutonValiderHypothese)
-        @hypothese.add_named(@boxHypothese, "Actif")
-        @hypothese.visible_child = @boutonHypothese
+        @hypothese.add(@boxHypothese)
+        puts(@grille.hypothese)
         boxVerticale.add(@hypothese)
+        @hypothese.show_all()
+        @hypothese.visible_child = @grille.hypothese == true ? @boxHypothese : @boutonHypotese
 
         @reinitialiser = Gtk::Button.new(:label => "Réinitialiser")
         boxVerticale.add(@reinitialiser)

--- a/src/ui/ChargementAventure.rb
+++ b/src/ui/ChargementAventure.rb
@@ -37,7 +37,7 @@ class ChargementAventure < Gtk::Box
     
         - Cliquez sur un continent débloqué pour vous y déplacer
         - Cliquez sur l'étiquette d'un niveau (rectangle avec le nombre d'étoiles) pour le jouer
-        - Cliquez en dehors d'un continent ou d'une étiquette pour revenir en arrière"
+        - Cliquez sur le bouton retour pour revenir en arrière"
         view.sensitive = false
 
         scroll = Gtk::ScrolledWindow.new()

--- a/src/ui/Didacticiel.rb
+++ b/src/ui/Didacticiel.rb
@@ -15,14 +15,23 @@ class Didacticiel < Gtk::Window
         vbox.margin = 15
 
         view = Gtk::TextView.new()
+        view.wrap_mode = :word
         view1 = Gtk::TextView.new()
+        view1.wrap_mode = :word
         view2 = Gtk::TextView.new()
+        view2.wrap_mode = :word
         view3 = Gtk::TextView.new()
+        view3.wrap_mode = :word
         view4 = Gtk::TextView.new()
+        view4.wrap_mode = :word
         view5 = Gtk::TextView.new()
+        view5.wrap_mode = :word
         view6 = Gtk::TextView.new()
+        view6.wrap_mode = :word
         view7 = Gtk::TextView.new()
+        view7.wrap_mode = :word
         view8 = Gtk::TextView.new()
+        view8.wrap_mode = :word
         view.buffer.text = 
 "   
     Règles : 
@@ -144,7 +153,7 @@ le choix de la valider, ou bien de l'annuler afin de revenir à l'état du jeu a
         
         scroll.add(vbox2)
         scroll.set_policy(:never, :automatic)
-        scroll.expand = true
+        scroll.vexpand = true
         
         bouton = Gtk::Button.new(label: "Quitter")
         bouton.signal_connect("clicked") { self.close() }


### PR DESCRIPTION
+ fix "Disparition des boutons annuler/refaire lorsque l'on part et retourne sur la grille en mode hypothèse"
+ fix "Supprimer dans la page de chargement du mode aventure la phrase qui dit que pour revenir en arrière il faut cliquer hors 'un continent ou d'une étiquette"
+ normalement fix "Taille de la fenêtre de Didacticiel"